### PR TITLE
fix Single arity template handlers are deprecated warning for rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - rbx-3
 matrix:
   allow_failures:
+    - rvm: rbx-3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,15 @@ install:
   - bundle install --retry=3
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - jruby-18mode
   - jruby-19mode
+  - jruby-head
   - rbx-3
-  - ruby-head
 matrix:
   allow_failures:
-  - rvm: rbx-3
-  - rvm: ruby-head
 addons:
   apt:
     packages:

--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ desc 'Run tests (default)'
 Rake::TestTask.new(:spec) do |t|
   t.test_files = FileList['spec/**/*_spec.rb']
   t.ruby_opts = ['-Ispec']
-  t.ruby_opts << '-rubygems' if defined? Gem
+  t.ruby_opts << '-rrubygems' if defined? Gem
 end

--- a/lib/action_view/template/handlers/twiml.rb
+++ b/lib/action_view/template/handlers/twiml.rb
@@ -3,9 +3,9 @@ require 'twilio-ruby'
 module ActionView
    module Template::Handlers
     class TwiML
-      def self.call(template)
+      def self.call(template, source = nil)
         "self.output_buffer = ::Twilio::TwiML::Response.new do |twiml|;" +
-        template.source +
+        (source || template.source) +
         ";end.to_xml;"
       end
     end

--- a/twiml_template.gemspec
+++ b/twiml_template.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tilt", ">= 1.3", "< 3"
   spec.add_dependency "twilio-ruby", ">= 3.0", "< 5.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rack-test"


### PR DESCRIPTION
Fix single arity template handlers are deprecated warning for Rails 6. 
Template handlers must now accept two parameters, the view object and the source for the view object. 
Change: >> ActionView::Template::Handlers::TwiML.call(template) 
To: >> ActionView::Template::Handlers::TwiML.call(template, source)